### PR TITLE
Fix failing ci by pinning jupyter-server

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,12 +7,13 @@ dependencies:
   - jupyterlab
   - matplotlib
   - cartopy
+  - jupyter_server<2
   - numpy
   - xarray
   - metpy
   - act-atmos>=1.2.0
   - imageio
+  - arm_pyart
   - pip
   - pip:
-    - git+https://github.com/ARM-DOE/pyart.git
     - sphinx-pythia-theme


### PR DESCRIPTION
Pin jupyter server to ensure cookbooks work again.
