### PR TITLE
Revert back config file to not run on binder

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,7 +17,9 @@ tags:
 
 # Execute the notebooks via binderbot
 execute:
-  execute_notebooks: binder
+  execute_notebooks: cache
+  timeout: 600
+  allow_errors: False  # cells with expected failures must set the `raises-exception` cell tag
 
 # Add a few extensions to help with parsing content
 parse:


### PR DESCRIPTION
The binder execution does not allow secrets to be passed, which is an issue. Revert back to using github actions.
