### PR TITLE
Update to latest template, including new binder

### DIFF
--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -19,12 +19,7 @@ jobs:
     with:
       environment_name: radar-cookbook-dev
       environment_file: environment.yml
-      path_to_notebooks: ./
 
   link-check:
     if: ${{ github.repository_owner == 'ProjectPythia' }}
     uses: ProjectPythia/cookbook-actions/.github/workflows/link-checker.yaml@main
-    with:
-      environment_name: radar-cookbook-dev
-      environment_file: environment.yml
-      path_to_notebooks: ./

--- a/.github/workflows/publish-book.yaml
+++ b/.github/workflows/publish-book.yaml
@@ -19,8 +19,6 @@ jobs:
       ARM_PASSWORD: ${{ secrets.ARM_PASSWORD }}
     with:
       environment_name: radar-cookbook-dev
-      environment_file: environment.yml
-      path_to_notebooks: ./
 
   deploy:
     needs: build

--- a/.github/workflows/trigger-book-build.yaml
+++ b/.github/workflows/trigger-book-build.yaml
@@ -13,7 +13,5 @@ jobs:
       ARM_PASSWORD: ${{ secrets.ARM_PASSWORD }}
     with:
       environment_name: radar-cookbook-dev
-      environment_file: environment.yml
-      path_to_notebooks: ./
-      use_cached_environment: 'true'  # This is default, not strickly needed. Set to 'false' to always build a new environment
       artifact_name: book-zip-${{ github.event.number }}
+      # Other input options are possible, see ProjectPythia/cookbook-actions/.github/workflows/build-book.yaml

--- a/.github/workflows/trigger-link-check.yaml
+++ b/.github/workflows/trigger-link-check.yaml
@@ -5,9 +5,3 @@ on:
 jobs:
   link-check:
     uses: ProjectPythia/cookbook-actions/.github/workflows/link-checker.yaml@main
-    with:
-      environment_name: radar-cookbook-dev
-      environment_file: environment.yml
-      path_to_notebooks: ./
-      use_cached_environment: 'true'
-      

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Radar Cookbook
 
 [![nightly-build](https://github.com/ProjectPythia/radar-cookbook/actions/workflows/nightly-build.yaml/badge.svg)](https://github.com/ProjectPythia/radar-cookbook/actions/workflows/nightly-build.yaml)
-[![Binder](http://binder.mypythia.org/badge_logo.svg)](http://binder.mypythia.org/v2/gh/ProjectPythia/radar-cookbook/main?labpath=notebooks)
+[![Binder](https://binder.projectpythia.org/badge_logo.svg)](https://binder.projectpythia.org/v2/gh/ProjectPythia/radar-cookbook/main?labpath=notebooks)
 
 This Project Pythia Cookbook covers the basics of working with weather radar data in Python.
 
@@ -41,12 +41,12 @@ If you are new to Py-ART, starting with the basics is a good place to start, and
 Here, we **apply** the lessons learned in the foundational material to various analysis workflows, including everything from reading in the data to plotting a beautiful visualization at the end. We include the additional dataset-specific details, focusing on building upon the foundational materials rather than duplicating previous content.
 
 ## Running the Notebooks
-You can either run the notebook using [Binder](https://mybinder.org/) or on your local machine.
+You can either run the notebook using [Binder](https://binder.projectpythia.org) or on your local machine.
 
 ### Running on Binder
 
 The simplest way to interact with a Jupyter Notebook is through
-[Binder](https://mybinder.org/), which enables the execution of a
+[Binder](https://binder.projectpythia.org), which enables the execution of a
 Jupyter Book in the cloud. The details of how this works are not
 important for now. All you need to know is how to launch a Pythia
 Foundations book chapter via Binder. Simply navigate your mouse to

--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,7 @@ title: Radar Cookbook
 author: Max Grover, Zachary Sherman
 logo: notebooks/images/logos/pythia_logo-white-rtext.svg
 email: projectpythia@ucar.edu
-copyright: '2022'
+copyright: '2023'
 
 description: A cookbook meant to work with various weather radar data.
 thumbnail: thumbnail.png
@@ -15,8 +15,8 @@ tags:
   packages:
     - Py-Art
 
-# Execute the notebooks via binderbot
 execute:
+  # To execute notebooks via a Binder instead, replace 'cache' with 'binder'
   execute_notebooks: cache
   timeout: 600
   allow_errors: False  # cells with expected failures must set the `raises-exception` cell tag
@@ -36,6 +36,8 @@ parse:
 
 sphinx:
   config:
+    linkcheck_ignore: ["https://doi.org/*"] # don't run link checker on DOI links since they are immutable
+    nb_execution_raise_on_error: true # raise exception in build if there are notebook errors (this flag is ignored if building on binde
     html_favicon: notebooks/images/icons/favicon.ico
     html_last_updated_fmt: '%-d %B %Y'
     html_theme: sphinx_pythia_theme
@@ -55,7 +57,7 @@ sphinx:
           icon: fab fa-youtube-square
           type: fontawesome
       launch_buttons:
-        binderhub_url: http://binder.mypythia.org
+        binderhub_url: https://binder.projectpythia.org
         notebook_interface: jupyterlab
         jupyterhub_url: https://jupyterhub.arm.gov
       extra_navbar: |


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
This PR brings the repo more or less up to date with the latest Cookbook template, including
- some simplifications to the workflows
- link to the new Pythia binder
- set the flag that raise build errors when notebook execution errors are found

plus some minor cosmetic stuff