### PR TITLE
Remove version pin for jupyter_server

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
   - jupyterlab
   - matplotlib
   - cartopy
-  - jupyter_server<2
+  - jupyter_server
   - numpy
   - xarray
   - metpy


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
The old version pin is not needed anymore and was causing environment conflict issues.