### PR TITLE
Use a more up-to-date python version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - pyviz
 dependencies:
-  - python=3.9
+  - python>=3.10
   - jupyter-book
   - jupyterlab
   - matplotlib


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
This PR removes the `python=3.9` version pin the environment file and replaces with a more recent python version.

This might resolve #114 when running on binder.