### PR TITLE
Fix missing images in Radar Basics

### DIFF
--- a/notebooks/radar-basics/radar-basics.ipynb
+++ b/notebooks/radar-basics/radar-basics.ipynb
@@ -4,8 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<img src=\"../gifs-clips/KFTG_loop.gif\" alt=\"KFTG radar loop, Source: National Weather Service\" width=400 height=400>\n",
-    "Clip Source: National Weather Service"
+    "![KFTG radar loop, Source: National Weather Service](../gifs-clips/KFTG_loop.gif)"
    ]
   },
   {
@@ -84,8 +83,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<img src=\"../images/radar.webp\" width=500 height=250/>\n",
-    "Image Source: Sundry Photography/Public domain"
+    "![Picture of a radar](../images/radar.webp)\n",
+    "\n",
+    "_Image Source: Sundry Photography/Public domain_"
    ]
   },
   {
@@ -106,15 +106,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Emmitted Energy"
+    "### Emitted Energy"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<video controls loop src=\"../gifs-clips/radop1.mp4\"/>\n",
-    "Clip Source: The COMET Program"
+    "![Emitted energy animation](../gifs-clips/radop1.mp4)\n",
+    "\n",
+    "_Clip Source: The [COMET](https://www.comet.ucar.edu) Program_"
    ]
   },
   {
@@ -259,7 +260,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.10"
+   "version": "3.12.3"
   },
   "nbdime-conflicts": {
    "local_diff": [


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
Closes #125 

I think the images are missing because of issues with how JupyterBook handles paths, e.g. https://jupyterbook.org/en/stable/advanced/html.html#use-raw-html-in-markdown

This PR replaces the HTML image tags with pure Markdown, which plays better with JupyterBook. We just lose the ability have video controls on the animation.