### PR TITLE
Add new gallery tags including event tags

### DIFF
--- a/_gallery_info.yml
+++ b/_gallery_info.yml
@@ -1,6 +1,11 @@
 thumbnail: thumbnail.png
 tags:
   domains:
+    - atmosphere
     - radar
   packages:
     - Py-Art
+    - Xradar
+  events:
+    - Cook-off 2023
+    - Cook-off 2024


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
This PR adds the new "event" tags for Cook-off 2023 and Cook-off 2024, as well as a few more relevant tags for gallery filtering.

No effect on the Cookbook itself, just on the gallery tags.