### PR TITLE
Fix array dimensions

### DIFF
--- a/notebooks/example-workflows/fastbarnes_interpolation_rhi.ipynb
+++ b/notebooks/example-workflows/fastbarnes_interpolation_rhi.ipynb
@@ -59,29 +59,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {
     "tags": []
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
-      "## You are using the Python ARM Radar Toolkit (Py-ART), an open source\n",
-      "## library for working with weather radar data. Py-ART is partly\n",
-      "## supported by the U.S. Department of Energy as part of the Atmospheric\n",
-      "## Radiation Measurement (ARM) Climate Research Facility, an Office of\n",
-      "## Science user facility.\n",
-      "##\n",
-      "## If you use this software to prepare a publication, please cite:\n",
-      "##\n",
-      "##     JJ Helmus and SM Collis, JORS 2016, doi: 10.5334/jors.119\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import pyart\n",
     "import act\n",

--- a/notebooks/example-workflows/fastbarnes_interpolation_rhi.ipynb
+++ b/notebooks/example-workflows/fastbarnes_interpolation_rhi.ipynb
@@ -59,11 +59,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "## You are using the Python ARM Radar Toolkit (Py-ART), an open source\n",
+      "## library for working with weather radar data. Py-ART is partly\n",
+      "## supported by the U.S. Department of Energy as part of the Atmospheric\n",
+      "## Radiation Measurement (ARM) Climate Research Facility, an Office of\n",
+      "## Science user facility.\n",
+      "##\n",
+      "## If you use this software to prepare a publication, please cite:\n",
+      "##\n",
+      "##     JJ Helmus and SM Collis, JORS 2016, doi: 10.5334/jors.119\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "import pyart\n",
     "import act\n",
@@ -274,7 +292,7 @@
     "        data = deepcopy(np.array(radar.fields[fields[j]]['data']))\n",
     "        # data = data.filled(np.nan)\n",
     "\n",
-    "        res_field[:,:,j] = barnes(np.asarray([rg_loc.ravel(),radar.gate_altitude['data'].ravel()]).transpose(),\n",
+    "        res_field[:,:,j] = barnes(np.asarray([rg_loc.ravel(),radar.gate_altitude['data'].ravel()]),\n",
     "                           data.ravel(),\n",
     "                           100,\n",
     "                           np.asarray([0,0]),\n",
@@ -397,7 +415,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.11.11"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
<!--
Project Pythia has automated review requests. If you are not ready for reviews on this contribution, please
open this Pull Request as a "Draft" by clicking the dropdown on the green "Create Pull Request" button in the
lower right corner here.
-->
This PR is an attempt to get the builds working again for this Cookbook. It's currently failing in the Fast Barnes notebook with
```
Cell In[7], line 63, in grid_rhi(file, z_res, rng_res, z_limits, rng_limits, fields)
     60     data = deepcopy(np.array(radar.fields[fields[j]]['data']))
     61     # data = data.filled(np.nan)
---> 63     res_field[:,:,j] = barnes(np.asarray([rg_loc.ravel(),radar.gate_altitude['data'].ravel()]).transpose(),
     64                        data.ravel(),
     65                        100,
     66                        np.asarray([0,0]),
     67                        100,
     68                        (len(z_pts),len(rng_pts)),
     69                        method=method,
     70                        num_iter = num_iter,
     71                        min_weight=0.0002
     72                       )
     75 data_dict = {}
     76 for k in range(len(fields)):

ValueError: could not broadcast input array from shape (1100,151) into shape (151,1100)
```

My guess is that just removing the `.transpose()` in line 63 will make the problem go away. I don't have access to the data to test locally, but we'll see if it passes here.